### PR TITLE
Alternative way to check for One-To-One relationships

### DIFF
--- a/DataLayer/CascadeEfClasses/Customer.cs
+++ b/DataLayer/CascadeEfClasses/Customer.cs
@@ -12,6 +12,9 @@ namespace DataLayer.CascadeEfClasses
     {
         public int Id { get; set; }
 
+        public int? AddressId { get; set; }
+        public Address Address { get; set; }
+
         public string CompanyName { get; set; }
 
         public HashSet<Quote> Quotes { get; set; }
@@ -31,7 +34,7 @@ namespace DataLayer.CascadeEfClasses
             {
                 customer.Quotes.Add(
                     new Quote {
-                        Name = $"quote{i}", UserId = userId, 
+                        Name = $"quote{i}", UserId = userId,
                         PriceInfo = new QuotePrice {UserId = userId, Price = i},
                         LineItems = new List<LineItem>
                         {

--- a/DataLayer/CascadeEfClasses/CustomerAddress.cs
+++ b/DataLayer/CascadeEfClasses/CustomerAddress.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) 2021 Jon P Smith, GitHub: JonPSmith, web: http://www.thereformedprogrammer.net/
+// Licensed under MIT license. See License.txt in the project root for license information.
+
+namespace DataLayer.CascadeEfClasses
+{
+    public class Address
+    {
+        public int Id { get; set; }
+        public string StreetName { get; set; }
+    }
+}

--- a/DataLayer/CascadeEfClasses/EmployeeContract.cs
+++ b/DataLayer/CascadeEfClasses/EmployeeContract.cs
@@ -11,6 +11,8 @@ namespace DataLayer.CascadeEfClasses
         [Key]
         public int EmployeeId { get; set; }
 
+        public Employee Employee { get; set; }
+
         public string ContractText { get; set; }
 
         public byte SoftDeleteLevel { get; set; }

--- a/DataLayer/CascadeEfCode/CascadeSoftDelDbContext.cs
+++ b/DataLayer/CascadeEfCode/CascadeSoftDelDbContext.cs
@@ -25,6 +25,7 @@ namespace DataLayer.CascadeEfCode
         public DbSet<Employee> Employees { get; set; }
         public DbSet<EmployeeContract> Contracts { get; set; }
 
+        public DbSet<Address> Addresses { get; set; }
         public DbSet<Customer> Companies { get; set; }
         public DbSet<Quote> Quotes { get; set; }
 
@@ -70,7 +71,7 @@ namespace DataLayer.CascadeEfCode
                     else
                         entityType.SetCascadeQueryFilter(CascadeQueryFilterTypes.CascadeSoftDelete, this);
                 }
-                
+
             }
 
             modelBuilder.Entity<ShadowCascadeDelClass>()

--- a/DataLayer/CascadeEfCode/CascadeSoftDelDbContext.cs
+++ b/DataLayer/CascadeEfCode/CascadeSoftDelDbContext.cs
@@ -40,7 +40,7 @@ namespace DataLayer.CascadeEfCode
 
             modelBuilder.Entity<Employee>()
                 .HasOne(x => x.Contract)
-                .WithOne()
+                .WithOne(x => x.Employee)
                 .HasForeignKey<EmployeeContract>(x => x.EmployeeId)
                 .OnDelete(DeleteBehavior.ClientCascade);
 

--- a/DataLayer/SingleEfClasses/Author.cs
+++ b/DataLayer/SingleEfClasses/Author.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) 2021 Jon P Smith, GitHub: JonPSmith, web: http://www.thereformedprogrammer.net/
+// Licensed under MIT license. See License.txt in the project root for license information.
+
+namespace DataLayer.SingleEfClasses
+{
+	public class Author
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+	}
+}

--- a/DataLayer/SingleEfClasses/Book.cs
+++ b/DataLayer/SingleEfClasses/Book.cs
@@ -12,6 +12,9 @@ namespace DataLayer.SingleEfClasses
         public string Title { get; set; }
         public bool SoftDeleted { get; set; }
 
+        public int? AuthorId { get; set; }
+        public Author Author { get; set; }
+
         public ICollection<Review> Reviews { get; set; }
     }
 }

--- a/DataLayer/SingleEfCode/SingleSoftDelDbContext.cs
+++ b/DataLayer/SingleEfCode/SingleSoftDelDbContext.cs
@@ -23,11 +23,12 @@ namespace DataLayer.SingleEfCode
             UserId = userId;
         }
 
+        public DbSet<Author> Authors { get; set; }
         public DbSet<Book> Books { get; set; }
         public DbSet<Order> Orders { get; set; }
 
         public DbSet<BookDDD> BookDdds { get; set; }
-        
+
         public DbSet<ShadowDelClass> ShadowDelClasses { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/SoftDeleteServices/Concrete/CascadeSoftDelService.cs
+++ b/SoftDeleteServices/Concrete/CascadeSoftDelService.cs
@@ -103,7 +103,7 @@ namespace SoftDeleteServices.Concrete
 
             //If is a one-to-one entity we return an error
             var keys = _context.Entry(softDeleteThisEntity).Metadata.GetForeignKeys();
-            if (!keys.All(x => x.DependentToPrincipal?.IsCollection == true || x.PrincipalToDependent?.IsCollection == true))
+            if (keys.Any(x => x.DependentToPrincipal?.IsCollection == false && x.PrincipalToDependent?.IsCollection == false))
                 //This it is a one-to-one entity
                 throw new InvalidOperationException("You cannot soft delete a one-to-one relationship. " +
                                                     "It causes problems if you try to create a new version.");

--- a/SoftDeleteServices/Concrete/CascadeSoftDelServiceAsync.cs
+++ b/SoftDeleteServices/Concrete/CascadeSoftDelServiceAsync.cs
@@ -103,7 +103,7 @@ namespace SoftDeleteServices.Concrete
 
             //If is a one-to-one entity we return an error
             var keys = _context.Entry(softDeleteThisEntity).Metadata.GetForeignKeys();
-            if (!keys.All(x => x.DependentToPrincipal?.IsCollection == true || x.PrincipalToDependent?.IsCollection == true))
+            if (keys.Any(x => x.DependentToPrincipal?.IsCollection == false && x.PrincipalToDependent?.IsCollection == false))
                 //This it is a one-to-one entity
                 throw new InvalidOperationException("You cannot soft delete a one-to-one relationship. " +
                                                     "It causes problems if you try to create a new version.");

--- a/SoftDeleteServices/Concrete/SingleSoftDeleteService.cs
+++ b/SoftDeleteServices/Concrete/SingleSoftDeleteService.cs
@@ -79,7 +79,7 @@ namespace SoftDeleteServices.Concrete
             if (softDeleteThisEntity == null) throw new ArgumentNullException(nameof(softDeleteThisEntity));
 
             var keys = _context.Entry(softDeleteThisEntity).Metadata.GetForeignKeys();
-            if (!keys.All(x => x.DependentToPrincipal?.IsCollection == true || x.PrincipalToDependent?.IsCollection == true))
+            if (keys.Any(x => x.DependentToPrincipal?.IsCollection == false && x.PrincipalToDependent?.IsCollection == false))
                 //This it is a one-to-one entity - setting a one-to-one as soft deleted causes problems when you try to create a replacement
                 throw new InvalidOperationException("You cannot soft delete a one-to-one relationship. " +
                                                     "It causes problems if you try to create a new version.");

--- a/SoftDeleteServices/Concrete/SingleSoftDeleteServiceAsync.cs
+++ b/SoftDeleteServices/Concrete/SingleSoftDeleteServiceAsync.cs
@@ -80,7 +80,7 @@ namespace SoftDeleteServices.Concrete
             if (softDeleteThisEntity == null) throw new ArgumentNullException(nameof(softDeleteThisEntity));
 
             var keys = _context.Entry(softDeleteThisEntity).Metadata.GetForeignKeys();
-            if (!keys.All(x => x.DependentToPrincipal?.IsCollection == true || x.PrincipalToDependent?.IsCollection == true))
+            if (keys.Any(x => x.DependentToPrincipal?.IsCollection == false && x.PrincipalToDependent?.IsCollection == false))
                 //This it is a one-to-one entity - setting a one-to-one as soft deleted causes problems when you try to create a replacement
                 throw new InvalidOperationException("You cannot soft delete a one-to-one relationship. " +
                                                     "It causes problems if you try to create a new version.");


### PR DESCRIPTION
Switch from failing when "one of the navigation-props is unknown and the other one is not a collection" (typically one-to-many) to fail when "both is explicitly not a collection" (one-to-one). This seems to fix the problem when the One-side does not have an explicit navigation-property (#1).